### PR TITLE
Use pausing fix from event-stream-client release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.3.3",
 			"license": "MIT",
 			"dependencies": {
-				"@treecg/actor-init-ldes-client": "https://github.com/redpencilio/event-stream-client/releases/download/actor-init-ldes-client-v3.0.0-feat-headers/treecg-actor-init-ldes-client-3.0.0.tgz",
+				"@treecg/actor-init-ldes-client": "https://github.com/redpencilio/event-stream-client/releases/download/actor-init-ldes-client-v3.0.0-fix-pausing/treecg-actor-init-ldes-client-3.0.0.tgz",
 				"rdf-js": "^4.0.2"
 			},
 			"devDependencies": {
@@ -2719,8 +2719,8 @@
 		},
 		"node_modules/@treecg/actor-init-ldes-client": {
 			"version": "3.0.0",
-			"resolved": "https://github.com/redpencilio/event-stream-client/releases/download/actor-init-ldes-client-v3.0.0-feat-headers/treecg-actor-init-ldes-client-3.0.0.tgz",
-			"integrity": "sha512-Xp/SUuPIaMCewnlY90H+r8Cee/hhGlr9fnDiCjCW//QJq+62Y3n3+O7W4Ac4+Dp3K2gitkGRhAwytKfs3CpJNQ==",
+			"resolved": "https://github.com/redpencilio/event-stream-client/releases/download/actor-init-ldes-client-v3.0.0-fix-pausing/treecg-actor-init-ldes-client-3.0.0.tgz",
+			"integrity": "sha512-4JPJ2DXjf8kZH+JdwI5g8TL3mxQ2Hce8RuwQSKMgb2fg1hAk4GxCTTZTzTQAenemhDWfphAZwTYVTPqfcfhRTw==",
 			"license": "ISC",
 			"dependencies": {
 				"@comunica/actor-dereference-rdf-parse": "^2.3.0",
@@ -15816,8 +15816,8 @@
 			}
 		},
 		"@treecg/actor-init-ldes-client": {
-			"version": "https://github.com/redpencilio/event-stream-client/releases/download/actor-init-ldes-client-v3.0.0-feat-headers/treecg-actor-init-ldes-client-3.0.0.tgz",
-			"integrity": "sha512-Xp/SUuPIaMCewnlY90H+r8Cee/hhGlr9fnDiCjCW//QJq+62Y3n3+O7W4Ac4+Dp3K2gitkGRhAwytKfs3CpJNQ==",
+			"version": "https://github.com/redpencilio/event-stream-client/releases/download/actor-init-ldes-client-v3.0.0-fix-pausing/treecg-actor-init-ldes-client-3.0.0.tgz",
+			"integrity": "sha512-4JPJ2DXjf8kZH+JdwI5g8TL3mxQ2Hce8RuwQSKMgb2fg1hAk4GxCTTZTzTQAenemhDWfphAZwTYVTPqfcfhRTw==",
 			"requires": {
 				"@comunica/actor-dereference-rdf-parse": "^2.3.0",
 				"@comunica/actor-http-fetch": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	},
 	"homepage": "https://github.com/redpencilio/ldes-consumer#readme",
 	"dependencies": {
-		"@treecg/actor-init-ldes-client": "https://github.com/redpencilio/event-stream-client/releases/download/actor-init-ldes-client-v3.0.0-feat-headers/treecg-actor-init-ldes-client-3.0.0.tgz",
+		"@treecg/actor-init-ldes-client": "https://github.com/redpencilio/event-stream-client/releases/download/actor-init-ldes-client-v3.0.0-fix-pausing/treecg-actor-init-ldes-client-3.0.0.tgz",
 		"rdf-js": "^4.0.2"
 	},
 	"devDependencies": {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -52,11 +52,11 @@ export default class Consumer {
     });
     stream.on('now only syncing', () => {
       stream.pause();
-  });
+    });
     stream.on("error", console.error);
     stream.on("pause", async () => {
       await UPDATE_QUEUE.push(async () => onFinish(stream.exportState()));
-    });
+    })
     stream.on("end", async () => {
       await UPDATE_QUEUE.push(async () => onFinish(stream.exportState()));
     })


### PR DESCRIPTION
This PR ensures the stream is paused when calling the pause() method when the 'now only syncing' event has been emitted. It relies on https://github.com/redpencilio/event-stream-client/releases/tag/actor-init-ldes-client-v3.0.0-fix-pausing.